### PR TITLE
tooltips not closing on webkit

### DIFF
--- a/src/lib/wikitools/Tooltip.svelte
+++ b/src/lib/wikitools/Tooltip.svelte
@@ -6,6 +6,12 @@
   let x;
   let y;
 
+  function tapped(event) {
+    isHovered = !isHovered;
+    x = event.pageX + 5;
+    y = event.pageY + 5;
+  }
+
   function mouseOver(event) {
     isHovered = true;
     x = event.pageX + 5;
@@ -24,7 +30,8 @@
 
 <svelte:window on:resize={mouseLeave} />
 
-<span on:mouseover={mouseOver} on:mouseleave={mouseLeave} on:mousemove={mouseMove} data-tooltip><slot /></span>{#if isHovered}
+<span on:touchstart={tapped} on:mouseover={mouseOver} on:mouseleave={mouseLeave} on:mousemove={mouseMove} data-tooltip><slot /></span>{#if isHovered}
+  <!-- we can't line break the {#if } here because else we get whitespace characters after the tooltip for some reason... -->
   <div style="top: {y}px; left: {x}px;" class="tooltip">
     {#if image}
       <img style="max-width: 100%;" src={image} alt="" />


### PR DESCRIPTION
Tooltips won't close on mobile after they were opened.
This solution might be a bit sloppy though and I don't know if such a toggle could be buggy itself...

`touchstart` might be a weird choice of event handler as well.